### PR TITLE
Add tox to execute flake8

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: alpine:latest 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Package installation for using tox
+        run: apk add --no-cache git python3 py3-pip && pip3 install tox
+      - name: Tox call tests
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          tox -v

--- a/app/app.py
+++ b/app/app.py
@@ -1,20 +1,25 @@
 from utils import cli
 import app.modules.nmap_parser as nmap
 
+
 def run():
     args = cli.get()
 
     filename = args.nmapxmlfile
 
     df_nmap_info = nmap.parser(filename)
-    
+
     if args.csvfile:
         filename_csv = filename + '.csv'
         try:
-            df_nmap_info.to_csv(filename_csv, sep=';', encoding='utf-8', header=None, index=False)
+            df_nmap_info.to_csv(filename_csv,
+                                sep=';',
+                                encoding='utf-8',
+                                header=None,
+                                index=False)
             print(f"|+| File created in {filename_csv}")
         except Exception as e:
-            print(f"|-| CSV file not created")
+            print("|-| CSV file not created")
             print(e)
 
     if args.xsltfile:
@@ -23,5 +28,5 @@ def run():
             df_nmap_info.style.to_excel(filename_xlsx)
             print(f"|+| File created in {filename_xlsx}")
         except Exception as e:
-            print(f"|-| XLSX file not created")
+            print("|-| XLSX file not created")
             print(e)

--- a/app/modules/nmap_parser.py
+++ b/app/modules/nmap_parser.py
@@ -8,19 +8,19 @@ def parser(nmapxmlfile):
     root = tree.getroot()
 
     output = []
-    
+
     for host in root.findall('host'):
         addr = host.find('address').get('addr')
         state = host.find('status').get('state')
         ports = host.find('ports')
         host_name = None
-        
+
         if host.find('hostnames') is not None:
             for hostname in host.find('hostnames'):
                 hostname_type = hostname.get('type')
                 if hostname_type == 'user':
                     host_name = hostname.get('name')
-        
+
         if state == 'up':
             for port in ports:
                 portid = port.get('portid')
@@ -37,8 +37,27 @@ def parser(nmapxmlfile):
                     version = port.find('service').get('version')
                     extrainfo = port.find('service').get('extrainfo')
 
-                    output.append([host_name, addr, state, portid, protocol, state_port, service_name, product, version, extrainfo])
+                    output.append([host_name,
+                                   addr,
+                                   state,
+                                   portid,
+                                   protocol,
+                                   state_port,
+                                   service_name,
+                                   product,
+                                   version,
+                                   extrainfo])
 
-        df = pd.DataFrame(output, columns= ['Hostname', 'IP', 'State', 'Port', 'Protocol', 'State Port', 'Service Name', 'Product', 'Version', 'Extrainfo'])
+        df = pd.DataFrame(output, columns=[
+                                            'Hostname',
+                                            'IP',
+                                            'State',
+                                            'Port',
+                                            'Protocol',
+                                            'State Port',
+                                            'Service Name',
+                                            'Product',
+                                            'Version',
+                                            'Extrainfo'])
 
     return df

--- a/nmap-parser.py
+++ b/nmap-parser.py
@@ -1,5 +1,5 @@
 from app.app import run
 
 # Run app/app.py
-if __name__=="__main__":
+if __name__ == "__main__":
     run()

--- a/scripts/csvtoxlsx.py
+++ b/scripts/csvtoxlsx.py
@@ -1,13 +1,15 @@
 import pandas as pd
 import argparse
 
-parser = argparse.ArgumentParser(add_help = True, description = '%(prog)s hunts all forms and inputs found in a list of urls.')
+parser = argparse.ArgumentParser(
+    add_help=True,
+    description='%(prog)s hunts all forms and inputs found in a list of urls.')
 
-parser.add_argument('-c','--csvfile', 
-                    help = 'XLSX output of CSV file', 
-                    nargs = '?', type=str)
+parser.add_argument('-c', '--csvfile',
+                    help='XLSX output of CSV file',
+                    nargs='?', type=str)
 
-if __name__=="__main__":
+if __name__ == "__main__":
     args = parser.parse_args()
 
     filename = args.csvfile
@@ -20,5 +22,5 @@ if __name__=="__main__":
         df.style.to_excel(filename_xlsx, index=False)
         print(f"|+| File created on {filename_xlsx}")
     except Exception as e:
-        print(f"|+| File not created")
+        print("|+| File not created")
         print(e)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+minversion = 3.8.0
+skipsdist = True
+envlist = pep8
+
+[testenv:pep8]
+deps = flake8
+commands = flake8 {posargs}
+
+[flake8]
+exclude=.tox

--- a/utils/cli.py
+++ b/utils/cli.py
@@ -1,22 +1,26 @@
 import sys
 import argparse
 
-parser = argparse.ArgumentParser(add_help = True, description = '%(prog)s hunts all forms and inputs found in a list of urls.')
+parser = argparse.ArgumentParser(
+    add_help=True,
+    description='%(prog)s hunts all forms and inputs found in a list of urls.')
 
-parser.add_argument('-x','--nmapxmlfile', 
-                    help = 'XML output of nmap scan', 
-                    nargs = '?', type=str)
-parser.add_argument('-C','--csvfile', 
-                    help = 'Output to CSV',
-                    action= "store_true")
-parser.add_argument('-X','--xsltfile', 
-                    help = 'Output to XLSX',
-                    action= "store_true") 
-parser.add_argument('-v','--verbose', 
-                    help = 'Verbose', action= "store_true")
+parser.add_argument('-x', '--nmapxmlfile',
+                    help='XML output of nmap scan',
+                    nargs='?', type=str)
+parser.add_argument('-C', '--csvfile',
+                    help='Output to CSV',
+                    action="store_true")
+parser.add_argument('-X', '--xsltfile',
+                    help='Output to XLSX',
+                    action="store_true")
+parser.add_argument('-v', '--verbose',
+                    help='Verbose', action="store_true")
+
 
 def get():
     return parser.parse_args()
+
 
 def help():
     return parser.print_help(sys.stderr)


### PR DESCRIPTION
I've seen this project and looks interesting and works very good.

I'd like to propose adding [tox](https://pypi.org/project/tox/) to execute [flake8](https://pypi.org/project/flake8/) as a linter for all this Python code. 

It includes:

- Add GitHub workflow with one job called `test` to execute `tox` every time there's a new Push or Pull Request action
- Add `tox.ini` file with the instruction to execute `flake8` under all the project.

The way it works is the following:

```
[2022-12-01 14:28:37] {afuscoar@afuscoar} (~/.Personal/Projects/nmap-parser) (feature/add-tox-and-fix-flake-errors)$ -> tox -v
using tox.ini: /home/afuscoar/.Personal/Projects/nmap-parser/tox.ini (pid 106022)
using tox-3.25.0 from /home/afuscoar/.local/lib/python3.10/site-packages/tox/__init__.py (pid 106022)
pep8 reusing: /home/afuscoar/.Personal/Projects/nmap-parser/.tox/pep8
[106026] /home/afuscoar/.Personal/Projects/nmap-parser$ /home/afuscoar/.Personal/Projects/nmap-parser/.tox/pep8/bin/python -m pip freeze >.tox/pep8/log/pep8-13.log
pep8 installed: flake8==6.0.0,mccabe==0.7.0,pycodestyle==2.10.0,pyflakes==3.0.1
pep8 run-test-pre: PYTHONHASHSEED='2999217220'
pep8 run-test: commands[0] | flake8
[106027] /home/afuscoar/.Personal/Projects/nmap-parser$ /home/afuscoar/.Personal/Projects/nmap-parser/.tox/pep8/bin/flake8
______________________________________________________________ summary ______________________________________________________________
  pep8: commands succeeded
  congratulations :)
```

If there's any error it won't finish successfully, e.g:

```
[2022-12-01 14:28:37] {afuscoar@afuscoar} (~/.Personal/Projects/nmap-parser) (main)$ -> tox -v
using tox.ini: /home/afuscoar/.Personal/Projects/nmap-parser/tox.ini (pid 106374)
using tox-3.25.0 from /home/afuscoar/.local/lib/python3.10/site-packages/tox/__init__.py (pid 106374)
pep8 reusing: /home/afuscoar/.Personal/Projects/nmap-parser/.tox/pep8
[106378] /home/afuscoar/.Personal/Projects/nmap-parser$ /home/afuscoar/.Personal/Projects/nmap-parser/.tox/pep8/bin/python -m pip freeze >.tox/pep8/log/pep8-15.log
pep8 installed: flake8==6.0.0,mccabe==0.7.0,pycodestyle==2.10.0,pyflakes==3.0.1
pep8 run-test-pre: PYTHONHASHSEED='165432923'
pep8 run-test: commands[0] | flake8
[106379] /home/afuscoar/.Personal/Projects/nmap-parser$ /home/afuscoar/.Personal/Projects/nmap-parser/.tox/pep8/bin/flake8
./app/app.py:4:1: E302 expected 2 blank lines, found 1
./app/app.py:10:1: W293 blank line contains whitespace
./app/app.py:14:80: E501 line too long (98 > 79 characters)
./app/app.py:17:19: F541 f-string is missing placeholders
./app/app.py:26:19: F541 f-string is missing placeholders
./app/app.py:27:21: W292 no newline at end of file
...
ERROR: InvocationError for command /home/afuscoar/.Personal/Projects/nmap-parser/.tox/pep8/bin/flake8 (exited with code 1)
______________________________________________________________ summary ______________________________________________________________
ERROR:   pep8: commands failed
[2022-12-01 14:28:37] {afuscoar@afuscoar} (~/.Personal/Projects/nmap-parser) (main)$ -> echo $?
1
```


- I've fixed the errors that the linter produced using [autopep8](https://pypi.org/project/autopep8/). It modified most of the problems and fixed them automatically. I fixed the rest by hand - manually -.

I've tested the scripts after the changes:

```
(venv) [2022-12-01 14:11:34] {afuscoar@afuscoar} (~/.Personal/Projects/nmap-parser) (feature/add-tox-and-fix-flake-errors)$ -> python3 nmap-parser.py -x nmap/tcp-full-scripts.xml -C
|+| File created in nmap/tcp-full-scripts.xml.csv
(venv) [2022-12-01 14:11:34] {afuscoar@afuscoar} (~/.Personal/Projects/nmap-parser) (feature/add-tox-and-fix-flake-errors)$ -> python3 nmap-parser.py -x nmap/tcp-full-scripts.xml -X
|+| File created in nmap/tcp-full-scripts.xml.xlsx
(venv) [2022-12-01 14:11:34] {afuscoar@afuscoar} (~/.Personal/Projects/nmap-parser) (feature/add-tox-and-fix-flake-errors)$ -> python3 nmap-parser.py -x nmap/tcp-full-scripts.xml -C -X       
|+| File created in nmap/tcp-full-scripts.xml.csv
|+| File created in nmap/tcp-full-scripts.xml.xlsx
```
Note:

- I've realized that in case `nmap` doesn't scan and save any `host` the code will produce the following error:
```
(venv) [2022-12-01 11:16:02] {afuscoar@afuscoar} (~/.Personal/Projects/nmap-parser) (feature/add-tox-and-fix-flake-errors)$ -> python3 nmap-parser.py -x nmap/tcp-full-scripts.xml -C
Traceback (most recent call last):
  File "/home/afuscoar/.Personal/Projects/nmap-parser/nmap-parser.py", line 5, in <module>
    run()
  File "/home/afuscoar/.Personal/Projects/nmap-parser/app/app.py", line 10, in run
    df_nmap_info = nmap.parser(filename)
  File "/home/afuscoar/.Personal/Projects/nmap-parser/app/modules/nmap_parser.py", line 64, in parser
    return df
UnboundLocalError: local variable 'df' referenced before assignment
```
It happens because it can't find any `host` tag when is processing the XML file using the `ET` module. It would be nice to fix it.

--

